### PR TITLE
Adjust to changed Travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
   - curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
   - sudo apt-get install -y nodejs
-  - mkdir ~/bin && ln -s `which nodejs` ~/bin/node && export PATH="~/bin/:$PATH"
+  - ln -s `which nodejs` ~/bin/node && export PATH="~/bin/:$PATH"
   - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
   - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - yarn install


### PR DESCRIPTION
The build environment changed and now ~/bin always exists. This caused our jobs to fail before running any tests.

https://docs.travis-ci.com/user/build-environment-updates/2017-07-12