### PR TITLE
Fix invalid syntax

### DIFF
--- a/_test/json/list.json
+++ b/_test/json/list.json
@@ -8,11 +8,16 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " single list item"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " single list item"
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -22,11 +27,16 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " another first lvl li"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " another first lvl li"
+                                        }
+                                    ]
                                 }
                             ]
                         },
@@ -37,11 +47,16 @@
                                     "type": "list_item",
                                     "content": [
                                         {
-                                            "type": "paragraph",
+                                            "type": "list_content",
                                             "content": [
                                                 {
-                                                    "type": "text",
-                                                    "text": " second level li"
+                                                    "type": "list_paragraph",
+                                                    "content": [
+                                                        {
+                                                            "type": "text",
+                                                            "text": " second level li"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }
@@ -55,11 +70,16 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " again first level li"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " again first level li"
+                                        }
+                                    ]
                                 }
                             ]
                         }

--- a/_test/json/list_ordered.json
+++ b/_test/json/list_ordered.json
@@ -8,11 +8,16 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " aaa"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " aaa"
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -22,11 +27,16 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " bbb"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " bbb"
+                                        }
+                                    ]
                                 }
                             ]
                         },
@@ -37,11 +47,16 @@
                                     "type": "list_item",
                                     "content": [
                                         {
-                                            "type": "paragraph",
+                                            "type": "list_content",
                                             "content": [
                                                 {
-                                                    "type": "text",
-                                                    "text": " ccc"
+                                                    "type": "list_paragraph",
+                                                    "content": [
+                                                        {
+                                                            "type": "text",
+                                                            "text": " ccc"
+                                                        }
+                                                    ]
                                                 }
                                             ]
                                         }
@@ -55,11 +70,16 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " ddd"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " ddd"
+                                        }
+                                    ]
                                 }
                             ]
                         }

--- a/_test/json/list_with_code.json
+++ b/_test/json/list_with_code.json
@@ -17,27 +17,20 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " For security reasons direct browsing of windows shares only works in Microsoft Internet Explorer per default (and only in the "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "\""
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "local zone"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "\""
-                                },
-                                {
-                                    "type": "text",
-                                    "text": ")."
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " For security reasons"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "..."
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -47,39 +40,58 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " For Mozilla and Firefox it can be enabled through different workaround mentioned in the Mozilla Knowledge Base. However, there will still be a JavaScript warning about trying to open a Windows Share. To remove this warning (for all users), put the following line in "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "conf\/lang\/en\/lang.php",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "code"
+                                            "type": "text",
+                                            "text": " For Mozilla and Firefox"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "..."
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
                                         }
                                     ]
                                 },
                                 {
-                                    "type": "text",
-                                    "text": " (more details at localization): "
+                                    "type": "code_block",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "<?php\n\/**\n * Customization of the english language file\n * Copy only the strings that needs to be modified\n *\/\n$lang['js']['nosmblinks'] = '';"
+                                        }
+                                    ],
+                                    "attrs": {
+                                        "class": "code ",
+                                        "data-filename": "conf\/lang\/en\/lang.php"
+                                    }
                                 }
                             ]
-                        },
+                        }
+                    ]
+                },
+                {
+                    "type": "list_item",
+                    "content": [
                         {
-                            "type": "code_block",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": "<?php\n\/**\n * Customization of the english language file\n * Copy only the strings that needs to be modified\n *\/\n$lang['js']['nosmblinks'] = '';"
+                                    "type": "list_paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": " final list item"
+                                        }
+                                    ]
                                 }
-                            ],
-                            "attrs": {
-                                "class": "code ",
-                                "data-filename": "conf\/lang\/en\/lang.php"
-                            }
+                            ]
                         }
                     ]
                 }

--- a/_test/json/list_with_code.txt
+++ b/_test/json/list_with_code.txt
@@ -1,7 +1,7 @@
 Notes:
 
-  * For security reasons direct browsing of windows shares only works in Microsoft Internet Explorer per default (and only in the "local zone").
-  * For Mozilla and Firefox it can be enabled through different workaround mentioned in the Mozilla Knowledge Base. However, there will still be a JavaScript warning about trying to open a Windows Share. To remove this warning (for all users), put the following line in ''conf/lang/en/lang.php'' (more details at localization): <code - conf/lang/en/lang.php>
+  * For security reasons...
+  * For Mozilla and Firefox... <code - conf/lang/en/lang.php>
 <?php
 /**
  * Customization of the english language file
@@ -9,3 +9,4 @@ Notes:
  */
 $lang['js']['nosmblinks'] = '';
 </code>
+  * final list item

--- a/_test/json/smileys.json
+++ b/_test/json/smileys.json
@@ -8,26 +8,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "8-)"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  8-)  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "8-)"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  8-)  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -39,26 +44,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "8-O"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  8-O  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "8-O"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  8-O  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -70,26 +80,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": ":-("
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  :-(  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": ":-("
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  :-(  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -101,26 +116,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": ":-)"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  :-)  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": ":-)"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  :-)  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -132,26 +152,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": ";-)"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  ;-)  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": ";-)"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  ;-)  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -163,26 +188,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "^_^"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  ^_^  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "^_^"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  ^_^  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -194,26 +224,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": ":?:"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  :?:  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": ":?:"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  :?:  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -225,26 +260,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "LOL"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  LOL  ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "LOL"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  LOL  ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -256,26 +296,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "FIXME"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "  FIXME ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "FIXME"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "  FIXME ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }
@@ -287,26 +332,31 @@
                     "type": "list_item",
                     "content": [
                         {
-                            "type": "paragraph",
+                            "type": "list_content",
                             "content": [
                                 {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": "DELETEME"
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " "
-                                },
-                                {
-                                    "type": "text",
-                                    "text": " DELETEME ",
-                                    "marks": [
+                                    "type": "list_paragraph",
+                                    "content": [
                                         {
-                                            "type": "unformatted"
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": "DELETEME"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " "
+                                        },
+                                        {
+                                            "type": "text",
+                                            "text": " DELETEME ",
+                                            "marks": [
+                                                {
+                                                    "type": "unformatted"
+                                                }
+                                            ]
                                         }
                                     ]
                                 }

--- a/parser/ListItemNode.php
+++ b/parser/ListItemNode.php
@@ -26,6 +26,13 @@ class ListItemNode extends Node
         $this->parent = &$parent;
 
         foreach ($data['content'] as $node) {
+            if ($node['type'] === 'list_content') {
+                foreach ($node['content'] as $subnode) {
+                    $this->subnodes[] = self::getSubNode($subnode, $this);
+                }
+                continue;
+            }
+
             $this->subnodes[] = self::getSubNode($node, $this);
         }
     }

--- a/parser/Node.php
+++ b/parser/Node.php
@@ -8,6 +8,7 @@ abstract class Node
     private static $nodeclass = [
         'text' => TextNode::class,
         'paragraph' => ParagraphNode::class,
+        'list_paragraph' => ParagraphNode::class,
         'bullet_list' => ListNode::class,
         'ordered_list' => ListNode::class,
         'heading' => HeadingNode::class,
@@ -30,7 +31,6 @@ abstract class Node
         'dwplugin_inline' => PluginNode::class,
         'dwplugin_block' => PluginNode::class,
     ];
-
 
     private static $linkClasses = [
         'interwikilink' => InterwikiLinkNode::class,

--- a/script/schema.js
+++ b/script/schema.js
@@ -13,39 +13,52 @@ const { Schema } = require('prosemirror-model');
 let { nodes, marks } = schema.spec;
 
 const doc = nodes.get('doc');
-doc.content = '(block | listblock | tableblock)+';
+doc.content = '(block | baseonly | container | protected_block | substitution_block)+';
 nodes = nodes.update('doc', doc);
 
 // heading shall only contain unmarked text
 const heading = nodes.get('heading');
 heading.content = 'text*';
 heading.marks = '';
+heading.group = 'baseonly';
 nodes.update('heading', heading);
 
-orderedList.group = 'listblock';
+orderedList.group = 'container';
 orderedList.content = 'list_item+';
 nodes = nodes.update('ordered_list', orderedList);
 
-bulletList.group = 'listblock';
+bulletList.group = 'container';
 bulletList.content = 'list_item+';
 nodes = nodes.update('bullet_list', bulletList);
 
-listItem.content = 'block+ listblock?';
+listItem.content = 'list_content (ordered_list | bullet_list)?';
 nodes = nodes.update('list_item', listItem);
 
 nodes = nodes.append(tableNodes({
-    tableGroup: 'tableblock',
+    tableGroup: 'container',
     cellContent: 'inline*',
     cellAttributes: {
         is_header: {},
     },
 }));
 
+
+nodes = nodes.addToEnd('list_content', {
+    content: '(list_paragraph | protected_block | substitution_block)*',
+    toDOM() { return ['div', { class: 'li' }, 0]; },
+
+});
+
+nodes = nodes.addToEnd('list_paragraph', {
+    content: 'inline*',
+    toDOM() { return ['div', 0]; },
+});
+
 // Nodes: https://prosemirror.net/docs/ref/#model.NodeSpec
 nodes = nodes.addToEnd('preformatted', {
     content: 'text*',
     marks: '',
-    group: 'block',
+    group: 'protected_block',
     code: true,
     toDOM() {
         return ['pre', { class: 'code' }, 0];
@@ -61,12 +74,13 @@ codeBlock.attrs = {
 codeBlock.toDOM = function toDOM(node) {
     return ['pre', node.attrs, 0];
 };
+codeBlock.group = 'protected_block';
 nodes = nodes.update('code_block', codeBlock);
 
 nodes = nodes.addToEnd('file_block', {
     content: 'text*',
     marks: '',
-    group: 'block',
+    group: 'protected_block',
     attrs: {
         class: { default: 'code file' },
         'data-filename': { default: null },
@@ -82,7 +96,7 @@ nodes = nodes.addToEnd('file_block', {
 nodes = nodes.addToEnd('html_block', {
     content: 'text*',
     marks: '',
-    group: 'block',
+    group: 'protected_block',
     attrs: {
         class: { default: 'html_block' },
     },
@@ -111,7 +125,7 @@ nodes = nodes.addToEnd('html_inline', {
 nodes = nodes.addToEnd('php_block', {
     content: 'text*',
     marks: '',
-    group: 'block',
+    group: 'protected_block',
     attrs: {
         class: { default: 'php_block' },
     },
@@ -138,8 +152,8 @@ nodes = nodes.addToEnd('php_inline', {
 });
 
 nodes = nodes.addToEnd('quote', {
-    content: 'block',
-    group: 'block',
+    content: 'block | quote | protected_block', // FIXME
+    group: 'container',
     inline: false,
     toDOM() {
         return ['blockquote', {}, ['div', { class: 'no' }, 0]];
@@ -192,7 +206,7 @@ nodes = nodes.addToEnd('footnote', {
 });
 
 nodes = nodes.addToEnd('rss', {
-    group: 'block',
+    group: 'substitution_block',
     atom: true,
     attrs: {
         class: { default: 'rss' },
@@ -214,7 +228,7 @@ nodes = nodes.addToEnd('dwplugin_block', {
     },
     draggable: true,
     inline: false,
-    group: 'block',
+    group: 'protected_block',
     defining: true,
     isolating: true,
     code: true,

--- a/script/schema.js
+++ b/script/schema.js
@@ -19,6 +19,7 @@ nodes = nodes.update('doc', doc);
 // heading shall only contain unmarked text
 const heading = nodes.get('heading');
 heading.content = 'text*';
+heading.marks = '';
 nodes.update('heading', heading);
 
 orderedList.group = 'listblock';

--- a/script/schema.js
+++ b/script/schema.js
@@ -52,7 +52,6 @@ nodes = nodes.addToEnd('preformatted', {
     },
 });
 
-// fixme we may want an explizit preformatted node so can tell preformatted and <code> apart
 const codeBlock = nodes.get('code_block');
 codeBlock.attrs = {
     class: { default: 'code' },

--- a/script/schema.js
+++ b/script/schema.js
@@ -23,14 +23,13 @@ heading.marks = '';
 nodes.update('heading', heading);
 
 orderedList.group = 'listblock';
-orderedList.content = 'listitem+';
+orderedList.content = 'list_item+';
 nodes = nodes.update('ordered_list', orderedList);
 
 bulletList.group = 'listblock';
-bulletList.content = 'listitem+';
+bulletList.content = 'list_item+';
 nodes = nodes.update('bullet_list', bulletList);
 
-listItem.group = 'listitem';
 listItem.content = 'block+ listblock?';
 nodes = nodes.update('list_item', listItem);
 

--- a/script/schema.js
+++ b/script/schema.js
@@ -183,52 +183,6 @@ nodes = nodes.addToEnd('link', {
     },
 });
 
-// nodes = nodes.addToEnd('interwikilink', {
-//     content: 'text|image',
-//     group: 'inline', // fixme should later be changed to substition? or add substitution?
-//     inline: true,
-//     atom: true,
-//     attrs: {
-//         class: {},
-//         href: {},
-//         'data-shortcut': {},
-//         'data-reference': {},
-//         title: { default: null },
-//     },
-//     toDOM(node) {
-//         return ['a', node.attrs, 0];
-//     },
-//     parseDom: [
-//         {
-//             tag: 'a[href].interwikilink',
-//             getAttrs(dom) {
-//                 return {
-//                     href: dom.getAttribute('href'),
-//                     title: dom.getAttribute('title'),
-//                     'data-shortcut': dom.getAttribute('data-shortcut'),
-//                     'data-reference': dom.getAttribute('data-reference'),
-//                     class: dom.getAttribute('class'),
-//                 };
-//             },
-//         },
-//     ],
-// });
-//
-// nodes = nodes.addToEnd('windowssharelink', {
-//     content: 'text|image',
-//     group: 'inline', // fixme should later be changed to substition? or add substitution?
-//     inline: true,
-//     atom: true,
-//     attrs: {
-//         class: {},
-//         href: {},
-//         title: {},
-//     },
-//     toDOM(node) {
-//         return ['a', node.attrs, 0];
-//     },
-// });
-
 nodes = nodes.addToEnd('footnote', {
     content: 'inline',
     group: 'inline',


### PR DESCRIPTION
This adjusts schema to disallow some syntax that is illegal in DokuWiki. It also gives the node-types in `script/schema.js` groups that are closer to DokuWiki's `PARSER_MODES`.

Fixes #28 
