### PR TITLE
💄 Set fixed height of editor to keep toolbar visible

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,5 +37,6 @@ jQuery(() => {
     }
 
     jQuery('#wiki__text').hide();
+    jQuery('#size__ctl').hide();
     jQuery('.editBox > .toolbar').hide();
 });

--- a/style.less
+++ b/style.less
@@ -1,6 +1,9 @@
 @import "customMenu.less";
 
 .ProseMirror {
+    overflow-y: auto;
+    height: 300px;
+
     .footnote {
         background-color: #ffdddd;
     }


### PR DESCRIPTION
This hides also the editor size controls, since they are not yet hooked up to the editor

Closes #26