### PR TITLE
✨ Add insertParagraph buttons for html_block

### DIFF
--- a/script/custom/paragraphButtons.js
+++ b/script/custom/paragraphButtons.js
@@ -1,0 +1,65 @@
+import { insertParagraphAtPos } from '../customCommands';
+
+/**
+ * @param {function} getView function that returns the current EditorView
+ * @param {string}   direction should be either 'before' or 'after'
+ * @return HTMLElement
+ */
+function getInsertParagraphButton(getView, direction) {
+    if (typeof jQuery === 'undefined') {
+        // early return during js schema testing
+        return null;
+    }
+
+    function dispatchInsertingParagraph(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const view = getView();
+        const pos = view.posAtDOM(event.target.parentNode);
+        const command = insertParagraphAtPos(pos, direction);
+        command(view.state, view.dispatch);
+    }
+
+    const $paragraphButton = jQuery('<button>');
+    $paragraphButton.css('visibility', 'hidden');
+    $paragraphButton.on('click', dispatchInsertingParagraph);
+    $paragraphButton.text('Add paragraph');
+    const $buttonWrapper = jQuery('<div>').append($paragraphButton);
+    $buttonWrapper.on('mouseleave', function () {
+        $paragraphButton.css('visibility', 'hidden');
+    });
+    $buttonWrapper.on('mouseenter', function (event) {
+        const view = getView();
+        const pos = view.posAtDOM(event.target.parentNode);
+        const command = insertParagraphAtPos(pos, direction);
+        if (command(view.state)) {
+            $paragraphButton.css('visibility', 'visible');
+        }
+    });
+
+    return $buttonWrapper.get(0);
+}
+
+/**
+ * Returns a DOM.Node for a div with a button to insert a new paragraph before the node to which it is attached
+ *
+ * This button has functionality to only appear when it is actually available
+ *
+ * @param {function} getView function that returns the current EditorView
+ * @return HTMLElement
+ */
+export function getInsertParagraphBeforeButton(getView) {
+    return getInsertParagraphButton(getView, 'before');
+}
+
+/**
+ * Returns a DOM.Node for a div with a button to insert a new paragraph after the node to which it is attached
+ *
+ * This button has functionality to only appear when it is actually available
+ *
+ * @param {function} getView function that returns the current EditorView
+ * @return HTMLElement
+ */
+export function getInsertParagraphAfterButton(getView) {
+    return getInsertParagraphButton(getView, 'after');
+}

--- a/script/customCommands.js
+++ b/script/customCommands.js
@@ -1,3 +1,5 @@
+import { Selection } from 'prosemirror-state';
+
 /**
  * Returns a command that tries to set the selected textblocks to the given node type with the given attributes.
  *
@@ -17,6 +19,34 @@ export function setBlockTypeNoAttrCheck(nodeType, attrs) { // eslint-disable-lin
         });
         if (!applicable) return false;
         if (dispatch) dispatch(state.tr.setBlockType(from, to, nodeType, attrs).scrollIntoView());
+        return true;
+    };
+}
+
+/**
+ * Returns a command that inserts a new paragraph before or after the node at the given position
+ *
+ * @param {int}    pos       position near which the paragraph should be inserted
+ * @param {string} direction should be 'before' or 'after'
+ * @return {function}
+ */
+export function insertParagraphAtPos(pos, direction = 'after') {
+    return function insertParagraphAtPosCommand(state, dispatch) {
+        const $pos = state.doc.resolve(pos);
+        const above = $pos.node(-1);
+        const beforeOrAfter = direction !== 'after' ? $pos.index(-1) : $pos.indexAfter(-1);
+        const type = above.contentMatchAt(beforeOrAfter).defaultType;
+
+        if (!above.canReplaceWith(beforeOrAfter, beforeOrAfter, type)) {
+            return false;
+        }
+
+        if (dispatch) {
+            const insertPos = direction !== 'after' ? $pos.before() : $pos.after();
+            const tr = state.tr.replaceWith(insertPos, insertPos, type.createAndFill());
+            tr.setSelection(Selection.near(tr.doc.resolve(insertPos), 1));
+            dispatch(tr.scrollIntoView());
+        }
         return true;
     };
 }

--- a/script/main.js
+++ b/script/main.js
@@ -12,7 +12,10 @@ import getNodeViews from './nodeviews';
 initializePublicAPI();
 
 window.Prosemirror.enableProsemirror = function enableProsemirror() {
-    const schema = new Schema(getSpec());
+
+    let view;
+
+    const schema = new Schema(getSpec(() => view));
 
     const mi = new MenuInitializer(schema);
 
@@ -24,7 +27,7 @@ window.Prosemirror.enableProsemirror = function enableProsemirror() {
     ];
 
     const json = jQuery('#dw__editform').find('[name=prosemirror_json]').get(0);
-    const view = new EditorView(document.querySelector('#prosemirror__editor'), {
+    view = new EditorView(document.querySelector('#prosemirror__editor'), {
         state: EditorState.create({
             doc: Node.fromJSON(schema, JSON.parse(json.value)),
             schema,

--- a/script/nodeviews/Footnote/footnoteSchema.js
+++ b/script/nodeviews/Footnote/footnoteSchema.js
@@ -1,7 +1,7 @@
 import getSpec from '../../schema';
 
-export default function getFootnoteSpec() {
-    const baseSpec = getSpec();
+export default function getFootnoteSpec(getView) {
+    const baseSpec = getSpec(getView);
     let footnoteSchemaNodes = baseSpec.nodes.remove('footnote').remove('heading');
     const doc = { ...footnoteSchemaNodes.get('doc') };
     const { notoc: ommitted, nocache: ommitted2, ...newDocAttrs } = doc.attrs;

--- a/script/nodeviews/FootnoteView.js
+++ b/script/nodeviews/FootnoteView.js
@@ -46,7 +46,7 @@ class FootnoteView extends AbstractNodeView {
             close: this.dispatchOuter.bind(this),
         });
         // And put a sub-ProseMirror into that
-        const footnoteSchema = new Schema(getFootnoteSpec());
+        const footnoteSchema = new Schema(getFootnoteSpec(() => this.innerView));
         const mi = new MenuInitializer(footnoteSchema);
         this.innerView = new EditorView(this.tooltip, {
             // You can use any node as an editor document

--- a/script/schema.js
+++ b/script/schema.js
@@ -7,9 +7,17 @@
 import { schema as schemaBasic } from 'prosemirror-schema-basic';
 import { tableNodes } from 'prosemirror-tables';
 import { bulletList, listItem, orderedList } from 'prosemirror-schema-list';
+import { getInsertParagraphBeforeButton, getInsertParagraphAfterButton } from './custom/paragraphButtons';
 
-export default function getSpec() {
+/**
+ * @param {function} getView function that returns the current EditorView
+ *
+ * @return {{nodes: OrderedMap, marks: OrderedMap }}
+ */
+export default function getSpec(getView) {
     let { nodes, marks } = schemaBasic.spec;
+    const buttonParagraphBefore = getInsertParagraphBeforeButton(getView);
+    const buttonParagraphAfter = getInsertParagraphAfterButton(getView);
 
     const doc = nodes.get('doc');
     doc.content = '(block | baseonly | container | protected_block | substitution_block)+';
@@ -89,7 +97,11 @@ export default function getSpec() {
         code: true,
         defining: true,
         toDOM(node) {
-            return ['pre', node.attrs, 0];
+            return ['div',
+                buttonParagraphBefore,
+                ['pre', node.attrs, 0],
+                buttonParagraphAfter,
+            ];
         },
     });
 


### PR DESCRIPTION
Exemplary implementation of the insertParagraph buttons.

The buttons need access to the current view to execute the command. Due to javascript scoping rules we have to provide a function to get the view when we need it instead of a reference to the view itself.

Also, strange things are happening if we create the buttons right in the schema node where we need them. Thus creating them in a local variable and adding them when needed.

@annda, @JayDeeDee Please especially point out any places where you'd feel that more comments would be helpful in the future.

ToDo:
* [ ] decide where we actually want to use them
* [ ] styling