### PR TITLE
🐛 Fix crash for listitems without content

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -168,6 +168,9 @@ class renderer_plugin_prosemirror extends Doku_Renderer
     public function listitem_open($level, $node = false)
     {
         $this->nodestack->addTop(new Node('list_item'));
+
+        $paragraphNode = new Node('paragraph');
+        $this->nodestack->addTop($paragraphNode);
     }
 
     /** @inheritDoc */

--- a/script/schema.js
+++ b/script/schema.js
@@ -34,7 +34,7 @@ export default function getSpec() {
     bulletList.content = 'list_item+';
     nodes = nodes.update('bullet_list', bulletList);
 
-    listItem.content = '(paragraph | protected_block | substitution_block)* (ordered_list | bullet_list)?';
+    listItem.content = '(paragraph | protected_block | substitution_block)+ (ordered_list | bullet_list)?';
     nodes = nodes.update('list_item', listItem);
 
     nodes = nodes.append(tableNodes({


### PR DESCRIPTION
If a listitem has no content, then parsing that empty listitem back into syntax caused a crash. This is now fixed, prevented and tested.

The trade-off is that syntax
```
  * <code>foo</code>
```
has now an extra paragraph in front of the code block.

See sentry issues WIKI-A1, WIKI-9G, WIKI-A2, WIKI-9H, WIKI-A0 ...