### PR TITLE
Add missing marks handling to smiley node

### DIFF
--- a/parser/SmileyNode.php
+++ b/parser/SmileyNode.php
@@ -3,16 +3,22 @@
 namespace dokuwiki\plugin\prosemirror\parser;
 
 
-class SmileyNode extends Node
+class SmileyNode extends Node implements InlineNodeInterface
 {
 
     protected $parent;
     protected $data;
 
-    public function __construct($data, Node $parent)
+    /** @var TextNode */
+    protected $textNode;
+
+    public function __construct($data, Node $parent, Node $previous = null)
     {
         $this->parent = &$parent;
         $this->data = $data;
+
+        // every inline node needs a TextNode to track marks
+        $this->textNode = new TextNode(['marks' => $data['marks']], $parent, $previous);
     }
 
     /**
@@ -23,5 +29,23 @@ class SmileyNode extends Node
     public function toSyntax()
     {
         return $this->data['attrs']['syntax'];
+    }
+
+    /**
+     * @param string $markType
+     */
+    public function increaseMark($markType)
+    {
+        return $this->textNode->increaseMark($markType);
+    }
+
+    /**
+     * @param string $markType
+     * @return int|null
+     * @throws \Exception
+     */
+    public function getStartingNodeMarkScore($markType)
+    {
+        return $this->textNode->getStartingNodeMarkScore($markType);
     }
 }


### PR DESCRIPTION
Fixes exceptions thrown when converting formatted smilies to nodes with marks.

Although marks make no sense for smiley nodes themselves, they must be preserved for proper handling of mark and node stacks. Other similar inline nodes already have a TextNode class member for that purpose. This commit adds one to smiley nodes.