### PR TITLE
Fix exceptions when rowspan is in the first column

### DIFF
--- a/_test/json/table_with_rowspan_first_col.json
+++ b/_test/json/table_with_rowspan_first_col.json
@@ -1,0 +1,222 @@
+{
+    "type": "doc",
+    "content": [
+        {
+            "type": "table",
+            "content": [
+                {
+                    "type": "table_row",
+                    "content": [
+                        {
+                            "type": "table_header",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Heading 1"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        },
+                        {
+                            "type": "table_header",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Heading 2"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        },
+                        {
+                            "type": "table_header",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Heading 3"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        }
+                    ],
+                    "attrs": {
+                        "columns": 3
+                    }
+                },
+                {
+                    "type": "table_row",
+                    "content": [
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "this cell spans vertically"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 3
+                            }
+                        },
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Row 1 Col 2"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        },
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Row 1 Col 3"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        }
+                    ],
+                    "attrs": {
+                        "columns": 3
+                    }
+                },
+                {
+                    "type": "table_row",
+                    "content": [
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Row 2 Col 2"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        },
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Row 2 Col 3"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        }
+                    ],
+                    "attrs": {
+                        "columns": 2
+                    }
+                },
+                {
+                    "type": "table_row",
+                    "content": [
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Row 3 Col 2"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        },
+                        {
+                            "type": "table_cell",
+                            "content": [
+                                {
+                                    "type": "paragraph",
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": "Row 3 Col 3"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attrs": {
+                                "colspan": 1,
+                                "rowspan": 1
+                            }
+                        }
+                    ],
+                    "attrs": {
+                        "columns": 2
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/_test/json/table_with_rowspan_first_col.txt
+++ b/_test/json/table_with_rowspan_first_col.txt
@@ -1,0 +1,4 @@
+^ Heading 1 ^ Heading 2 ^ Heading 3 ^
+| this cell spans vertically | Row 1 Col 2 | Row 1 Col 3 |
+| ::: | Row 2 Col 2 | Row 2 Col 3 |
+| ::: | Row 3 Col 2 | Row 3 Col 3 |

--- a/parser/TableRowNode.php
+++ b/parser/TableRowNode.php
@@ -29,7 +29,7 @@ class TableRowNode extends Node
             if (!empty($rowSpans[$colIndex])) {
                 $doc .= '| ::: ';
                 $rowSpans[$colIndex] -= 1;
-                $colspan = 1;
+                $colSpan = 1;
                 continue;
             }
             $tableCell = array_shift($this->tableCells);


### PR DESCRIPTION
Fixes #75 Editor crashed with rowspan in the first column: a typo broke loop counter