### PR TITLE
Fix updating images/media nodes

### DIFF
--- a/script/nodeviews/MediaForm.js
+++ b/script/nodeviews/MediaForm.js
@@ -1,18 +1,22 @@
 import CustomForm from './CustomForm';
 
+let mfInstance = null;
+
 class MediaForm extends CustomForm {
     /**
      * @param {string} id ID of the form
      *
-     * @return {void}
      */
     constructor(id = 'prosemirror-mediaform') {
         super(id);
 
-        this.name = LANG.plugins.prosemirror.mediaConfig;
-
-        this.$form.find('.js-open-mediamanager').on('click', MediaForm.openMediaManager);
-        window.pmMediaSelect = this.mediaSelect.bind(this);
+        // prevent repeated initialization
+        if (!mfInstance) {
+            this.name = LANG.plugins.prosemirror.mediaConfig;
+            this.$form.find('.js-open-mediamanager').on('click', MediaForm.openMediaManager);
+            window.pmMediaSelect = this.mediaSelect.bind(this);
+            mfInstance = this;
+        }
     }
 
     /**

--- a/script/nodeviews/MediaView.js
+++ b/script/nodeviews/MediaView.js
@@ -65,6 +65,7 @@ class MediaView extends AbstractNodeView {
                     newAttrs,
                     this.node.marks,
                 ));
+                this.deselectNode();
             },
         ));
     }


### PR DESCRIPTION
It is currently not possible to update / replace a media node.

This PR introduces two changes to fix this:
- do not attach multiple handlers to the same form object
- properly close and reset the form on update