### PR TITLE
Escape text that should not be interpreted as Wiki syntax

### DIFF
--- a/_test/json/unformatted.json
+++ b/_test/json/unformatted.json
@@ -1,0 +1,14 @@
+{
+    "type": "doc",
+    "content": [
+        {
+            "type": "paragraph",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "__foo//bar%%"
+                }
+            ]
+        }
+    ]
+}

--- a/_test/json/unformatted.txt
+++ b/_test/json/unformatted.txt
@@ -1,0 +1,1 @@
+%%__%%foo%%//%%bar<nowiki>%%</nowiki>

--- a/parser/TextNode.php
+++ b/parser/TextNode.php
@@ -105,7 +105,25 @@ class TextNode extends Node implements InlineNodeInterface
 
     public function getInnerSyntax()
     {
-        return $this->text;
+        if ($this->marks['unformatted']) {
+            return $this->text;
+        }
+        return preg_replace_callback(
+            "/\bhttps?:\/\/|__+|\/\/+|%%+|''+|\*\*+/",
+            function ($matches)
+            {
+                switch ($matches[0][0]) {
+                    case 'h':
+                        // We matched http(s)://
+                        return $matches[0];
+                    case '%':
+                        return '<nowiki>' . $matches[0] . '</nowiki>';
+                    default:
+                        return '%%' . $matches[0] . '%%';
+                }
+            },
+            $this->text
+        );
     }
 
 


### PR DESCRIPTION
This is not intended as a ready-to-merge pull request – it still needs some work and I'd like some feedback.

When I type `__foo//bar%%` into the WYSIWYG editor, then a JSON structure as in the new test file `unformatted.json` is sent.  This needs to be escaped.  I modified `getInnerSyntax()` to do just that.  Ist das im Sinne des Erfinders?

This works, but it can not be tested in the same way as the other pairs of txt/json files because roundtripping will result in a different JSON structure that splits up the string into five sections, three of them marked as "unformatted".

I see several options how to make this work:

* Write a separate test in PHP for this feature
* Introduce files with "double extensions" `.renderer.json` and `.jsonParser.json` that are only intended for `renderer.test.php` or `jsonParser.test.php`
* A quite radical approach: Get rid of the "unformatted" mark altogether because unformatted text will render correctly when sent like in `unformatted.json` with the `getInnerSyntax()` function from this pull request.