### PR TITLE
Wrap bug fix

### DIFF
--- a/parser/ParagraphNode.php
+++ b/parser/ParagraphNode.php
@@ -29,7 +29,8 @@ class ParagraphNode extends Node
     {
         $doc = '';
         foreach ($this->subnodes as $subnode) {
-            $doc .= $subnode->toSyntax();
+			if (is_a($subnode, TableNode::class)) $doc .= "\n";
+			$doc .= $subnode->toSyntax();
         }
         return $doc;
     }


### PR DESCRIPTION
Currently, if you create a ListItem in the built-in DokuWik editor that contains the following code:

   - listitem with wrap <WRAP>
| Test1 | Test2 |
| Result1 | Result2 |
</WRAP>

And then switch to Prosemirror editor and back to DokuWiki editor, this code will be corrupted. This fix prevents code corruption.