### PR TITLE
Ignore empty headings

### DIFF
--- a/parser/HeadingNode.php
+++ b/parser/HeadingNode.php
@@ -17,7 +17,7 @@ class HeadingNode extends Node
 
     public function __construct($data, Node $parent)
     {
-        if (empty($data['content'][0]['text'])) {
+        if (trim($data['content'][0]['text']) === '') {
             return;
         }
 

--- a/parser/HeadingNode.php
+++ b/parser/HeadingNode.php
@@ -17,6 +17,10 @@ class HeadingNode extends Node
 
     public function __construct($data, Node $parent)
     {
+        if (empty($data['content'][0]['text'])) {
+            return;
+        }
+
         $this->parent = &$parent;
         $this->level = $data['attrs']['level'];
         $this->text = $data['content'][0]['text'];


### PR DESCRIPTION
Empty text nodes are not allowed and will throw an exception anyway, so we have to prevent their creation.