### PR TITLE
Fix if page have no heading and begins with ordered or bullet list

### DIFF
--- a/action/parser.php
+++ b/action/parser.php
@@ -108,7 +108,7 @@ class action_plugin_prosemirror_parser extends DokuWiki_Action_Plugin
             return;
         }
         if ($syntax !== null) {
-            $TEXT = trim($syntax);
+            $TEXT = $syntax;
         }
     }
 


### PR DESCRIPTION
Try to create and preview page without heading and which begins with ordered or bullet list, for example:
```
  - First item
  - Second item
  - Third item
```
First list item will be corrupted.

This pull request fix this.