### PR TITLE
Add support for Shift+Enter key, used to add new line in codeblocks if they in lists

### DIFF
--- a/script/plugins/Keymap/keymap.js
+++ b/script/plugins/Keymap/keymap.js
@@ -1,6 +1,6 @@
 import { keymap } from 'prosemirror-keymap';
 import { splitListItem } from 'prosemirror-schema-list';
-import { baseKeymap, chainCommands } from 'prosemirror-commands';
+import { baseKeymap, chainCommands, newlineInCode } from 'prosemirror-commands';
 import { redo, undo } from 'prosemirror-history';
 
 function getKeymapPlugin(schema) {
@@ -22,12 +22,15 @@ function getKeymapPlugin(schema) {
     if (!isMac) {
         historyKeymap['Mod-y'] = redo;
     }
-
+	
+    const newLineInCodeblock = { 'Shift-Enter': chainCommands(newlineInCode) };
+	
     const mergedKeymap = {
         ...baseKeymap,
         ...customKeymap,
         ...combinedKeymapUnion,
         ...historyKeymap,
+        ...newLineInCodeblock,
     };
 
     return keymap(mergedKeymap);


### PR DESCRIPTION
Unable to add new line in code block if it is inside ordered or bullet list, for example try press <kbd>Enter</kbd> inside code block to add new line between first and third line:
```
  - First item<code>
First line
Third line
</code>
  - Second item
  - Third item
```
This pull request adds <kbd>Shift</kbd> + <kbd>Enter</kbd> key to add new lines inside code block.