### PR TITLE
Fix the removal of line breaks inside WRAP if it is inside a list

### DIFF
--- a/parser/ParagraphNode.php
+++ b/parser/ParagraphNode.php
@@ -29,7 +29,9 @@ class ParagraphNode extends Node
     {
         $doc = '';
         foreach ($this->subnodes as $subnode) {
+            if (is_a($subnode, ParagraphNode::class)) $doc .= "\n";
             $doc .= $subnode->toSyntax();
+            if (is_a($subnode, ParagraphNode::class)) $doc .= "\n";
         }
         return $doc;
     }


### PR DESCRIPTION
Fix the removal of line breaks inside WRAP if it is inside a list.
Example page code:
```
  - First item <WRAP>
First WRAP line

Second WRAP line
</WRAP>
  - Second item
```
