### PR TITLE
Styling cleanup

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -45,23 +45,10 @@ window.Prosemirror.enableProsemirror = function enableProsemirror() {
         nodeViews: getNodeViews(),
     });
     window.view = view;
-    jQuery(window).on('scroll.prosemirror_menu', () => {
-        const $container = jQuery('#prosemirror__editor');
-        const $menuBar = $container.find('.menubar');
-        const docViewTop = jQuery(window).scrollTop();
-        const containerTop = $container.offset().top;
-
-        if (docViewTop > containerTop) {
-            $menuBar.css('position', 'fixed');
-        } else {
-            $menuBar.css('position', '');
-        }
-    });
 };
 
 window.Prosemirror.destroyProsemirror = function destroyProsemirror() {
     if (window.view && typeof window.view.destroy === 'function') {
         window.view.destroy();
     }
-    jQuery(window).off('scroll.prosemirror_menu');
 };

--- a/style.less
+++ b/style.less
@@ -3,11 +3,14 @@
 @highlight-odd-ini_text: fade(@ini_background, 95%);
 @highlight-even-ini_text: fade(@ini_text, 5%);
 
+@border-radius: 6px;
+@border-style: 1px solid #ddd;
+
 .ProseMirror {
     padding: 4px 8px 4px 14px;
     white-space: pre-wrap;
-	border-radius: 6px;
-	border: 1px solid #ddd;
+	border-radius: @border-radius;
+	border: @border-style;
     outline: none;
     counter-reset: prosemirror-footnote;
 
@@ -74,6 +77,14 @@
 
     .selectedCell {
         background-color: rgba(200, 200, 255, 0.4);
+    }
+}
+
+.prosemirror_wrapper {
+    .menubar {
+	    border-radius: @border-radius;
+        border: @border-style;
+	    margin-bottom: 0.5rem;
     }
 }
 

--- a/style.less
+++ b/style.less
@@ -6,13 +6,8 @@
 .ProseMirror {
     padding: 4px 8px 4px 14px;
     white-space: pre-wrap;
-    background: repeating-linear-gradient(
-        -45deg,
-        @highlight-odd-ini_text,
-        @highlight-odd-ini_text 10px,
-        @highlight-even-ini_text 10px,
-        @highlight-even-ini_text 20px,
-    );
+	border-radius: 6px;
+	border: 1px solid #ddd;
     outline: none;
     counter-reset: prosemirror-footnote;
 

--- a/style.less
+++ b/style.less
@@ -85,11 +85,11 @@
 .dokuwiki {
     .plugin_prosemirror_useWYSIWYG {
         position: absolute;
-        top: 55px;
-        right: 30px;
-        padding: 5px;
-        color: black;
-        background: yellow none;
+        top: 2.9em;
+	    right: 2em;
+        padding: 3px 8px;
+        background-color: white;
+        color: #444;
     }
 
     .footnote-tooltip {

--- a/style.less
+++ b/style.less
@@ -1,8 +1,5 @@
 @import "customMenu.less";
 
-// This can be used to have the menu bar stick below the header
-@sticky-offset: 0rem;
-
 @highlight-odd-ini_text: fade(@ini_background, 95%);
 @highlight-even-ini_text: fade(@ini_text, 5%);
 
@@ -88,7 +85,7 @@
     display: block;
     .menubar {
         position: sticky;
-        top: @sticky-offset;
+        top: 0; // Users/Theme developers can override this to stick it below a sticky header
 	    border-radius: @border-radius;
         border: @border-style;
 	    margin-bottom: 0.5rem;

--- a/style.less
+++ b/style.less
@@ -1,5 +1,8 @@
 @import "customMenu.less";
 
+// This can be used to have the menu bar stick below the header
+@sticky-offset: 0rem;
+
 @highlight-odd-ini_text: fade(@ini_background, 95%);
 @highlight-even-ini_text: fade(@ini_text, 5%);
 
@@ -81,7 +84,11 @@
 }
 
 .prosemirror_wrapper {
+    position: relative;
+    display: block;
     .menubar {
+        position: sticky;
+        top: @sticky-offset;
 	    border-radius: @border-radius;
         border: @border-style;
 	    margin-bottom: 0.5rem;

--- a/style.less
+++ b/style.less
@@ -175,3 +175,9 @@
         z-index: 105; // set to what plugin edittable defines
     }
 }
+
+// Workaround for sticky menubar in argon
+main {
+    // Sticky elements can't have parents with overflow: hidden
+    overflow: unset !important;
+}


### PR DESCRIPTION
Some UI polish. 

- Striped background removed
- Toggle button easier on the eyes
- No more jumping when scrolling the menu bar out of view

Further information is inside the individual commits. 

<img width="863" alt="Screen Shot 2021-08-20 at 10 46 21" src="https://user-images.githubusercontent.com/1337470/130206931-8caf9c7c-1fdd-407c-8e1e-149e0ec3c8e3.png">

https://user-images.githubusercontent.com/1337470/130206804-689fa869-8154-4dbb-9e00-8e4fa86fa3e9.mov

Fixes #88. 