### PR TITLE
Enable indentation using Tab/Shift-Tab

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -10,6 +10,7 @@ import buildInputRules from './plugins/InputRules/inputrules';
 import initializePublicAPI from './initializePublicAPI';
 import MenuInitializer from './plugins/Menu/MenuInitializer';
 import getNodeViews from './nodeviews';
+import { disableDefaultTabBehavior } from './plugins/disableDefaultTabBehavior';
 
 initializePublicAPI();
 
@@ -25,6 +26,7 @@ window.Prosemirror.enableProsemirror = function enableProsemirror() {
         getKeymapPlugin(schema),
         buildInputRules(schema),
         tableEditing(schema),
+        disableDefaultTabBehavior(),
     ];
 
     const json = jQuery('#dw__editform').find('[name=prosemirror_json]').get(0);

--- a/script/plugins/Keymap/keymap.js
+++ b/script/plugins/Keymap/keymap.js
@@ -1,7 +1,8 @@
 import { keymap } from 'prosemirror-keymap';
-import { splitListItem } from 'prosemirror-schema-list';
+import { splitListItem, sinkListItem, liftListItem } from 'prosemirror-schema-list';
 import { baseKeymap, chainCommands } from 'prosemirror-commands';
 import { redo, undo } from 'prosemirror-history';
+
 
 function getKeymapPlugin(schema) {
     // Mac OS has its own typical shortcuts
@@ -23,11 +24,17 @@ function getKeymapPlugin(schema) {
         historyKeymap['Mod-y'] = redo;
     }
 
+    const indentationKeymap = {
+        Tab: sinkListItem(schema.nodes.list_item),
+        'Shift-Tab': liftListItem(schema.nodes.list_item),
+    };
+
     const mergedKeymap = {
         ...baseKeymap,
         ...customKeymap,
         ...combinedKeymapUnion,
         ...historyKeymap,
+        ...indentationKeymap,
     };
 
     return keymap(mergedKeymap);

--- a/script/plugins/disableDefaultTabBehavior.js
+++ b/script/plugins/disableDefaultTabBehavior.js
@@ -1,0 +1,31 @@
+import { Plugin } from 'prosemirror-state';
+
+/**
+ * Disable the browser's default behavior on tab, which is required to support indentation using Tab/Shift-Tab
+ */
+export function disableDefaultTabBehavior() {
+    function preventTab(e) {
+        if (e.key === 'Tab') {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }
+
+    let setupComplete = false;
+
+    return new Plugin({
+        view: () => ({
+            update: () => {
+                if (setupComplete) return;
+
+                window.addEventListener('keydown', preventTab);
+                setupComplete = true;
+            },
+            destroy: () => {
+                window.removeEventListener('keydown', preventTab);
+            },
+        }),
+    });
+}
+
+export default disableDefaultTabBehavior;


### PR DESCRIPTION
Also disables jumping away from the editor using tab, which is standard behavior across editors.

The plugin for this is from: https://dragonman225.js.org/prosemirror-notes.html#https://www.notion.so/bcc3359ace95416193dce898baa06000