### PR TITLE
Prevent the switch-WYSIWYG button from submitting the form.

### DIFF
--- a/action/editor.php
+++ b/action/editor.php
@@ -131,6 +131,7 @@ class action_plugin_prosemirror_editor extends DokuWiki_Action_Plugin
     {
         $button = new ButtonElement('prosemirror', $this->getLang('switch_editors'));
         $button->addClass('button plugin_prosemirror_useWYSIWYG');
+        $button->attr('type', 'button');
         if ($this->isForceWYSIWYG()) {
             $button->attr('style', 'display: none;');
         }

--- a/script.js
+++ b/script.js
@@ -153,6 +153,7 @@ function toggleEditor() {
 
     const $current = DokuCookie.getValue('plugin_prosemirror_useWYSIWYG');
     DokuCookie.setValue('plugin_prosemirror_useWYSIWYG', $current ? '' : '1');
+    return false;
 }
 
 /**


### PR DESCRIPTION
Set both type="button" and return false from jQuery handler (redundant
solutions).

Solves  #165