### PR TITLE
Switch WYSIWYG button is too close to the top.

### DIFF
--- a/style.less
+++ b/style.less
@@ -96,7 +96,7 @@
 .dokuwiki {
     .plugin_prosemirror_useWYSIWYG {
         position: absolute;
-        top: 2.9em;
+        top: 3.3em;
         right: 2em;
         padding: 3px 8px;
         color: #444;


### PR DESCRIPTION
It partly covers the first line of the intro text.