### PR TITLE
Toggle button

### DIFF
--- a/action/editor.php
+++ b/action/editor.php
@@ -89,12 +89,12 @@ class action_plugin_prosemirror_editor extends DokuWiki_Action_Plugin
         $form = $event->data;
 
         if(is_a($form, \dokuwiki\Form\Form::class)) {
-            $form->addElement($this->buildToggleButton());
+            $form->addElement($this->buildToggleButton(), 0);
             $form->setHiddenField('prosemirror_json',$prosemirrorJSON);
             $form->addHTML('<div class="prosemirror_wrapper" id="prosemirror__editor"></div>', 1);
         } else {
             // todo remove when old stable is no longer supported
-            $form->addElement($this->buildOldToggleButton());
+            $form->insertElement(0, $this->buildOldToggleButton());
             $form->addHidden('prosemirror_json',$prosemirrorJSON);
             $form->insertElement(1, '<div class="prosemirror_wrapper" id="prosemirror__editor"></div>');
         }
@@ -106,7 +106,7 @@ class action_plugin_prosemirror_editor extends DokuWiki_Action_Plugin
      * Creates it as hidden if forcing WYSIWYG
      *
      * @deprecated use buildToggleButton instead
-     * @return array the pseudo-tag expected by \Doku_Form::addElement
+     * @return array the pseudo-tag expected by \Doku_Form::insertElement
      */
     protected function buildOldToggleButton()
     {

--- a/action/editor.php
+++ b/action/editor.php
@@ -63,6 +63,13 @@ class action_plugin_prosemirror_editor extends DokuWiki_Action_Plugin
             return;
         }
 
+        /** @var Doku_Form|\dokuwiki\Form\Form $form */
+        $form = $event->data;
+
+        // return early if content is not editable
+        if ($this->isReadOnly($form)) return;
+
+
         $useWYSIWYG = get_doku_pref('plugin_prosemirror_useWYSIWYG', false);
 
         $prosemirrorJSON = '';
@@ -85,10 +92,7 @@ class action_plugin_prosemirror_editor extends DokuWiki_Action_Plugin
             }
         }
 
-        /** @var Doku_Form|\dokuwiki\Form\Form $form */
-        $form = $event->data;
-
-        if(is_a($form, \dokuwiki\Form\Form::class)) {
+        if (is_a($form, \dokuwiki\Form\Form::class)) {
             $form->addElement($this->buildToggleButton(), 0);
             $form->setHiddenField('prosemirror_json',$prosemirrorJSON);
             $form->addHTML('<div class="prosemirror_wrapper" id="prosemirror__editor"></div>', 1);
@@ -321,6 +325,27 @@ class action_plugin_prosemirror_editor extends DokuWiki_Action_Plugin
     {
         global $JSINFO;
         $JSINFO['SMILEY_CONF'] = getSmileys();
+    }
+
+    /**
+     * Returns true if the current content is read only
+     *
+     * @todo remove Doku_Form case when the class is removed
+     *
+     * @param $form
+     * @return bool
+     */
+    protected function isReadOnly($form)
+    {
+        if (is_a($form, \dokuwiki\Form\Form::class)) {
+            $textareaPos = $form->findPositionByType('textarea');
+            $readonly = $textareaPos !== false && !empty($form->getElementAt($textareaPos)->attr('readonly'));
+        } else {
+            /** @var Doku_Form $form */
+            $textareaPos = $form->findElementByType('wikitext');
+            $readonly = $textareaPos !== false && !empty($form->getElementAt($textareaPos)['readonly']);
+        }
+        return $readonly;
     }
 }
 

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -6,7 +6,7 @@
  */
 
 // custom language strings for the plugin
-$lang['switch_editors'] = 'Schalte WYSIWYG-Editor um';
+$lang['switch_editors'] = 'Syntax &#11020; Visueller Editor umschalten';
 
 $lang['link target'] = 'Linkziel';
 $lang['type:wiki page'] = 'Eine Seite in diesem Wiki';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -6,7 +6,7 @@
  */
 
 // custom language strings for the plugin
-$lang['switch_editors'] = 'Toggle WYSIWYG editor';
+$lang['switch_editors'] = 'Toggle syntax &#11020; visual editor';
 
 $lang['link target'] = 'Link target';
 $lang['type:wiki page'] = 'A page in this wiki';

--- a/style.less
+++ b/style.less
@@ -95,8 +95,8 @@
 
 .dokuwiki {
     .plugin_prosemirror_useWYSIWYG {
-        margin-bottom: 0.75rem;
         display: flex;
+        margin-bottom: 0.75rem;
     }
 
     .footnote-tooltip {

--- a/style.less
+++ b/style.less
@@ -95,12 +95,8 @@
 
 .dokuwiki {
     .plugin_prosemirror_useWYSIWYG {
-        position: absolute;
-        top: 2.9em;
-        right: 2em;
-        padding: 3px 8px;
-        color: #444;
-        background-color: white;
+        margin-bottom: 0.75rem;
+        display: flex;
     }
 
     .footnote-tooltip {


### PR DESCRIPTION
This PR moves the toggle button HTML to the beginning of edit form, as suggested in #185. This should work with most templates. Tested with default, sprintdoc and bootstrap3.

<img width="554" alt="prosemirror_toggle_dokuwiki" src="https://user-images.githubusercontent.com/17853330/219124589-9450cfa3-52fe-4488-a95d-9582e044f423.png">

I have changed the text of the button, making it hopefully more user friendly for those who find the default syntax editor "too technical".

An additional check for `readonly` attribute of the edit form in ed43ceba1fe3cd2d2a9ce0233dbf13a78b83df84 should fix #86 