### PR TITLE
Restore stickiness of the menu bar

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -47,6 +47,20 @@ window.Prosemirror.enableProsemirror = function enableProsemirror() {
         nodeViews: getNodeViews(),
     });
     window.view = view;
+
+    // sticky menubar
+    jQuery(window).on('scroll.prosemirror_menu', () => {
+        const $container = jQuery('#prosemirror__editor');
+        const $menuBar = $container.find('.menubar');
+        const docViewTop = jQuery(window).scrollTop();
+        const containerTop = $container.offset().top;
+
+        if (docViewTop > containerTop) {
+            $menuBar.css('position', 'fixed');
+        } else {
+            $menuBar.css('position', '');
+        }
+    });
 };
 
 window.Prosemirror.destroyProsemirror = function destroyProsemirror() {

--- a/style.less
+++ b/style.less
@@ -85,8 +85,6 @@
     display: block;
 
     .menubar {
-        position: sticky;
-        top: 0; // Users/Theme developers can override this to stick it below a sticky header
         margin-bottom: 0.5rem;
         border: @border-style;
         border-radius: @border-radius;


### PR DESCRIPTION
lost in c398821008dbb8c42204091a7c873b84ff486710 because the solution intentionally ignored the fact that templates have conflicting CSS.

The author suggested overrides in userstyles, but I don't think this is a good idea. Especially because users of Prosemirror WYSIWYG tend not to be code tinkerers - this is why they shy away from wiki syntax in the first place.